### PR TITLE
[#33] remove logback (avoid warning about multiple bindings) 

### DIFF
--- a/cebes-dataframe-spark/build.sbt
+++ b/cebes-dataframe-spark/build.sbt
@@ -5,7 +5,7 @@ scalastyleConfig := baseDirectory.value / "../build/scalastyle-config.xml"
 libraryDependencies ++= Seq(
 
   "com.typesafe.scala-logging" %% "scala-logging-slf4j" % Common.scalaLoggingSlf4jVersion,
-  "ch.qos.logback" % "logback-classic" % Common.logbackClassicVersion,
+  // "ch.qos.logback" % "logback-classic" % Common.logbackClassicVersion,
 
   "org.apache.spark" %% "spark-core" % Common.sparkVersion % "provided"
     exclude("com.google.inject", "guice")

--- a/cebes-dataframe-spark/src/test/resources/log4j.properties
+++ b/cebes-dataframe-spark/src/test/resources/log4j.properties
@@ -1,16 +1,19 @@
-log4j.rootLogger=INFO
+log4j.rootLogger=INFO, MASTER_LOGGER
 
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.Target=System.out
 log4j.appender.Console.layout=org.apache.log4j.PatternLayout
-log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} (%F:%M) - %m%n
+log4j.appender.Console.layout.ConversionPattern=[%-5p] %d{ISO8601} %c{1} (%F:%M) - %m%n
 
 log4j.appender.MASTER_LOGGER=org.apache.log4j.RollingFileAppender
-log4j.appender.MASTER_LOGGER.File=${cebes.logs.dir}/cebes-dataframe-spark-test.log
+log4j.appender.MASTER_LOGGER.File=${cebes.logs.dir}cebes-dataframe-spark-test.log
 log4j.appender.MASTER_LOGGER.MaxFileSize=10MB
 log4j.appender.MASTER_LOGGER.MaxBackupIndex=100
 log4j.appender.MASTER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+log4j.appender.MASTER_LOGGER.layout.ConversionPattern=[%-5p] %d{ISO8601} %c{2} (%F:%M) - %m%n
 
 # disable some noisy Spark-related loggers
-log4j.logger.org.apache.spark.scheduler = WARN
+log4j.logger.org.apache.spark=WARN
+log4j.logger.Remoting=WARN
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.apache.parquet=WARN

--- a/cebes-http-server/build.sbt
+++ b/cebes-http-server/build.sbt
@@ -8,8 +8,8 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http-testkit" % "2.4.10" % "test",
   "com.softwaremill.akka-http-session" %% "core" % "0.2.7",
 
-  "com.typesafe.scala-logging" %% "scala-logging-slf4j" % "2.1.2",
-  "ch.qos.logback" % "logback-classic" % "1.1.7",
+  "com.typesafe.scala-logging" %% "scala-logging-slf4j" % Common.scalaLoggingSlf4jVersion,
+  //"ch.qos.logback" % "logback-classic" % "1.1.7",
 
   "org.apache.spark" %% "spark-core" % Common.sparkVersion % "provided"
     exclude("com.google.inject", "guice")

--- a/cebes-http-server/src/test/resources/log4j.properties
+++ b/cebes-http-server/src/test/resources/log4j.properties
@@ -1,18 +1,19 @@
-log4j.rootLogger=INFO
+log4j.rootLogger=INFO, MASTER_LOGGER
 
 log4j.appender.Console=org.apache.log4j.ConsoleAppender
 log4j.appender.Console.Target=System.out
 log4j.appender.Console.layout=org.apache.log4j.PatternLayout
-log4j.appender.Console.layout.ConversionPattern=%d{ISO8601} %-5p %c{1} (%F:%M) - %m%n
+log4j.appender.Console.layout.ConversionPattern=[%-5p] %d{ISO8601} %c{1} (%F:%M) - %m%n
 
 log4j.appender.MASTER_LOGGER=org.apache.log4j.RollingFileAppender
-log4j.appender.MASTER_LOGGER.File=${cebes.logs.dir}/cebes-http-server-test.log
+log4j.appender.MASTER_LOGGER.File=${cebes.logs.dir}cebes-dataframe-spark-test.log
 log4j.appender.MASTER_LOGGER.MaxFileSize=10MB
 log4j.appender.MASTER_LOGGER.MaxBackupIndex=100
 log4j.appender.MASTER_LOGGER.layout=org.apache.log4j.PatternLayout
-log4j.appender.MASTER_LOGGER.layout.ConversionPattern=%d{ISO8601} %-5p %c{2} (%F:%M) - %m%n
+log4j.appender.MASTER_LOGGER.layout.ConversionPattern=[%-5p] %d{ISO8601} %c{2} (%F:%M) - %m%n
 
 # disable some noisy Spark-related loggers
-log4j.logger.org.apache.spark = WARN
-log4j.logger.org.spark_project.jetty = WARN
-log4j.logger.org.apache.spark.sql.hive.client = WARN
+log4j.logger.org.apache.spark=WARN
+log4j.logger.Remoting=WARN
+log4j.logger.org.eclipse.jetty=WARN
+log4j.logger.org.apache.parquet=WARN


### PR DESCRIPTION
and update log4j configuration (for tests)

Partially solved https://github.com/phvu/cebes-server/issues/33. Logs in production (running Spark with Yarn) needs to be considered.
