### PR TITLE
[#71] added test for window

### DIFF
--- a/cebes-dataframe-json/src/test/scala/io/cebes/json/CebesJsonProtocolSuite.scala
+++ b/cebes-dataframe-json/src/test/scala/io/cebes/json/CebesJsonProtocolSuite.scala
@@ -84,6 +84,7 @@ class CebesJsonProtocolSuite extends FunSuite {
       """{"non-sense": 100}""".parseJson.convertTo[Schema]
     }
   }
+
   test("DataSample empty case") {
     val sample = new DataSample(Schema(), Seq.empty[Seq[Any]])
     val s = sample.toJson.compactPrint


### PR DESCRIPTION
https://github.com/phvu/cebes-server/issues/71

Turn out `CalendarIntervalType` isn't fully supported in Spark yet: https://issues.apache.org/jira/browse/SPARK-9221

We already have test for `CalendarIntervalType` in `CebesJsonProtocolSuite`